### PR TITLE
Added a Javascript Obfuscator

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "express": "*"
   },
   "dependencies": {
+    "javascript-obfuscator": "^2.10.2",
     "mime2": "latest"
   }
 }


### PR DESCRIPTION
Hey!

I needed an Express Middleware which automatically obfuscates static .js files and serves them to the client and I couldn't find any npm packages so I forked your project.

Changes are:
- I added javascript-obfuscator npm package
- The options argument for the main module now take the property { obfuscator: {} } (see the reference [here](https://github.com/javascript-obfuscator/javascript-obfuscator#javascript-obfuscator-options))

I tested it thorougly and everything works.

(Did I pull-request this correctly? I've never done this before)